### PR TITLE
remove hprint from mc tests

### DIFF
--- a/src/mc_rand_walk.c
+++ b/src/mc_rand_walk.c
@@ -104,7 +104,6 @@ uint64_t thread_main() {
   player_init(&pos);
   while (epoch < MAX_EPOCHS) {
     player_walk(&pos, WALK_STEPS);
-    bp_hprint(core_id);
     player_sync(core_id, epoch);
     epoch = epoch + 1;
   }

--- a/src/mc_sanity.c
+++ b/src/mc_sanity.c
@@ -37,8 +37,6 @@ uint64_t main(uint64_t argc, char * argv[]) {
       sum += MATRIX[i*NUM_CORES + core_id];
     }
 
-    bp_hprint((uint8_t)sum);
-
     if (sum == K) {
       bp_finish(0);
     } else {

--- a/src/mc_work_share_sort.c
+++ b/src/mc_work_share_sort.c
@@ -88,7 +88,6 @@ uint64_t thread_main() {
     uint32_t arr_index = getNextArray(&array);
     if (array) {
       sortArray(array);
-      bp_hprint(arr_index);
     } else {
       break;
     }


### PR DESCRIPTION
This PR removes the unsupported hprint function call from the mc_* test programs.