### PR TITLE
Adding the eaddr fault and domain fault tests

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -49,7 +49,8 @@ BP_DEMOS_C = \
   timer_interrupt_test \
   loop_test \
   cache_flush \
-  stream_hammer
+  stream_hammer \
+	domain_fault
 
 BP_DEMOS_S = \
 	simple                \

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -50,7 +50,8 @@ BP_DEMOS_C = \
   loop_test \
   cache_flush \
   stream_hammer \
-	domain_fault
+	domain_fault \
+	eaddr_fault
 
 BP_DEMOS_S = \
 	simple                \

--- a/src/domain_fault.c
+++ b/src/domain_fault.c
@@ -1,0 +1,57 @@
+#include <stdint.h>
+#include <bp_utils.h>
+
+/*
+ * This test checks if the domain fault checking is working correctly
+ * The domain register is an 8-bit register and a domain is enabled if the corresponding bit is set as 1
+ * For example: domain = 00001011 indicates domains 0, 1 and 3 are enabled
+ */
+
+uint64_t *cfg_domain_reg_addr = 0x200009;
+uint64_t *domain_4 = 0x8000000000;
+uint64_t *domain_7 = 0xe000000000;
+
+void trap_success(){
+  uint64_t mcause;
+  __asm__ __volatile__ ("csrr %0, mcause": "=r"(mcause));
+
+  // Trap should be on store access fault
+  if(mcause == 7)
+    bp_finish(0);
+
+  bp_finish(1);
+}
+
+void main(uint64_t argc, char * argv[]) {
+  uint64_t domain_data;
+  
+  // Use the alternate handler for trapping
+  __asm__ __volatile__ ("csrw mtvec, %0": : "r"(&trap_success));  
+
+  // Checking if the default enabled domain is 0;
+  domain_data = *cfg_domain_reg_addr;
+  if(domain_data != 1)
+    bp_finish(1);
+   
+  // Disabling domain 0
+  *cfg_domain_reg_addr = 0;
+
+  domain_data = *cfg_domain_reg_addr;
+  // Domain 0 must still be active
+  if(domain_data != 1)
+    bp_finish(1);
+
+  // Enabling domain 4
+  *cfg_domain_reg_addr = 16;
+
+  // Accessing domain 4. This must print a warning on the screen in simulation
+  *domain_4 = 0xdeadbeef;
+
+  // Accessing domain 7. This should trap
+  *domain_7 = 0xdeadbeef; 
+
+  // Test fails if previous instruction didn't trap
+  bp_finish(1);
+}
+
+

--- a/src/eaddr_fault.c
+++ b/src/eaddr_fault.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <bp_utils.h>
+
+void trap_success() {
+      uint64_t mcause;
+
+      __asm__ __volatile__ ("csrr %0, mcause" : "=r" (mcause));
+
+      if (mcause == 15)
+        bp_finish(0);
+
+      bp_finish(1);
+}
+
+void main(uint64_t argc, char * argv[]) {
+      // MPP bits are set as 01 (supervisor) and MPRV bit is set to 1
+      uint64_t mstatus = ((1 << 17) | (1 << 11));
+      // satp has the PPN as 0 and mode = sv39
+      uint64_t satp = 0x8000000000000000;
+
+      // Set up trap to alternate handler
+      __asm__ __volatile__ ("csrw mtvec, %0": : "r" (&trap_success));
+
+      __asm__ __volatile__ ("csrw mstatus, %0": : "r" (mstatus));
+      __asm__ __volatile__ ("csrw satp, %0": : "r" (satp));
+
+      // Sending a store to an address that would trigger an eaddr page fault
+      __asm__ __volatile__ ("li t0, 0x470000000000");
+      __asm__ __volatile__ ("sd zero, 0(t0)");
+     
+      bp_finish(1);
+}


### PR DESCRIPTION
This PR adds the following tests:

- Domain fault test: Enables and disables different domains to test the functionality of the domain fault check.
- Eaddr fault test: Writes to an illegal address to test the functionality of the eaddr specification (bits 63-39 of the eaddr must be the same as bit 38).