### PR TITLE
bp-tests: add directed M-mode interrupt-priority tests

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -12,6 +12,9 @@ BP_TESTS_C = \
   stream_hammer         \
   domain_fault          \
   eaddr_fault           \
+  interrupt_priority    \
+  interrupt_priority_simultaneous \
+  interrupt_priority_race \
   instr_fault_mtval     \
   instr_fault_stval     \
   instret_smode         \
@@ -65,4 +68,3 @@ BP_TESTS_CPP = \
   map                   \
 
 BP_TESTS = $(BP_TESTS_C) $(BP_MULTICORE_TESTS_C) $(BP_ACCELERATOR_TESTS_C) $(BP_TESTS_CPP)
-

--- a/src/interrupt_priority.c
+++ b/src/interrupt_priority.c
@@ -14,12 +14,16 @@ static inline void mmio_write64(uint64_t addr, uint64_t val) {
   *(volatile uint64_t *)addr = val;
 }
 
+static inline void mmio_write32(uint64_t addr, uint32_t val) {
+  *(volatile uint32_t *)addr = val;
+}
+
 static inline uint64_t mmio_read64(uint64_t addr) {
   return *(volatile uint64_t *)addr;
 }
 
-static inline void clint_set_msip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+static inline void clint_set_msip(uint32_t val) {
+  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
 }
 
 static inline void clint_set_mtimecmp(uint64_t val) {

--- a/src/interrupt_priority.c
+++ b/src/interrupt_priority.c
@@ -1,0 +1,119 @@
+// This test checks M-mode interrupt priority ordering using CLINT/PLIC MMIO.
+#include <stdint.h>
+#include "bp_utils.h"
+
+// CLINT/PLIC base and offsets (see bp_common_clint_pkgdef.svh)
+#define CLINT_BASE_ADDR        0x00300000ull
+#define CLINT_MIPI_OFFSET      0x0000ull
+#define CLINT_MTIMECMP_OFFSET  0x4000ull
+#define CLINT_MTIME_OFFSET     0xBFF8ull
+#define CLINT_PLIC_OFFSET      0xB000ull
+#define CLINT_PLIC_STRIDE      0x0008ull
+
+static inline void mmio_write64(uint64_t addr, uint64_t val) {
+  *(volatile uint64_t *)addr = val;
+}
+
+static inline uint64_t mmio_read64(uint64_t addr) {
+  return *(volatile uint64_t *)addr;
+}
+
+static inline void clint_set_msip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+}
+
+static inline void clint_set_mtimecmp(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
+}
+
+static inline uint64_t clint_read_mtime(void) {
+  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
+}
+
+static inline void clint_set_meip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
+}
+
+volatile uint64_t step = 0;
+
+void trap_handler(void) __attribute__((interrupt));
+void trap_handler(void) {
+  uint64_t mcause;
+  __asm__ __volatile__ ("csrr %0, mcause" : "=r" (mcause));
+
+  if ((mcause >> 63) == 0)
+    bp_finish(1);
+
+  uint64_t ecode = mcause & 0xfff;
+
+  if (step == 0) {
+    if (ecode != 11)
+      bp_finish(1);
+
+    clint_set_meip(0);
+
+    // Allow lower-priority interrupts only after MEIP is serviced.
+    uint64_t mie;
+    __asm__ __volatile__ ("csrr %0, mie" : "=r" (mie));
+    mie |= (1ULL << 3) | (1ULL << 7);
+    __asm__ __volatile__ ("csrw mie, %0" : : "r" (mie));
+
+    // Arm software and timer interrupts for the next steps.
+    clint_set_msip(1);
+    clint_set_mtimecmp(clint_read_mtime());
+
+    step = 1;
+    return;
+  }
+
+  if (step == 1) {
+    if (ecode != 3)
+      bp_finish(1);
+
+    clint_set_msip(0);
+    step = 2;
+    return;
+  }
+
+  if (step == 2) {
+    if (ecode != 7)
+      bp_finish(1);
+
+    // Clear MTIP by moving compare far into the future.
+    clint_set_mtimecmp(~0ull);
+    bp_finish(0);
+  }
+
+  bp_finish(1);
+}
+
+int main(uint64_t argc, char * argv[]) {
+  __asm__ __volatile__ ("csrw mtvec, %0" : : "r" (&trap_handler));
+
+  // Keep global MIE off while programming pending sources.
+  uint64_t mstatus;
+  __asm__ __volatile__ ("csrr %0, mstatus" : "=r" (mstatus));
+  mstatus &= ~(1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  // Enable only external interrupt first.
+  uint64_t mie = (1ULL << 11);
+  __asm__ __volatile__ ("csrw mie, %0" : : "r" (mie));
+
+  // Clear stale pending interrupts.
+  clint_set_msip(0);
+  clint_set_meip(0);
+  clint_set_mtimecmp(~0ull);
+
+  // Arm only MEIP before enabling MIE.
+  clint_set_meip(1);
+  __asm__ __volatile__ ("fence iorw, iorw" : : : "memory");
+
+  // Enable global machine interrupts.
+  mstatus |= (1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  for (uint64_t i = 0; i < 1000000; i++) { }
+
+  bp_finish(1);
+}

--- a/src/interrupt_priority.c
+++ b/src/interrupt_priority.c
@@ -1,42 +1,7 @@
 // This test checks M-mode interrupt priority ordering using CLINT/PLIC MMIO.
 #include <stdint.h>
 #include "bp_utils.h"
-
-// CLINT/PLIC base and offsets (see bp_common_clint_pkgdef.svh)
-#define CLINT_BASE_ADDR        0x00300000ull
-#define CLINT_MIPI_OFFSET      0x0000ull
-#define CLINT_MTIMECMP_OFFSET  0x4000ull
-#define CLINT_MTIME_OFFSET     0xBFF8ull
-#define CLINT_PLIC_OFFSET      0xB000ull
-#define CLINT_PLIC_STRIDE      0x0008ull
-
-static inline void mmio_write64(uint64_t addr, uint64_t val) {
-  *(volatile uint64_t *)addr = val;
-}
-
-static inline void mmio_write32(uint64_t addr, uint32_t val) {
-  *(volatile uint32_t *)addr = val;
-}
-
-static inline uint64_t mmio_read64(uint64_t addr) {
-  return *(volatile uint64_t *)addr;
-}
-
-static inline void clint_set_msip(uint32_t val) {
-  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
-}
-
-static inline void clint_set_mtimecmp(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
-}
-
-static inline uint64_t clint_read_mtime(void) {
-  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
-}
-
-static inline void clint_set_meip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
-}
+#include "interrupt_priority.h"
 
 volatile uint64_t step = 0;
 
@@ -113,11 +78,11 @@ int main(uint64_t argc, char * argv[]) {
   clint_set_meip(1);
   __asm__ __volatile__ ("fence iorw, iorw" : : : "memory");
 
-  // Enable global machine interrupts.
+  //// Enable global machine interrupts.
   mstatus |= (1ULL << 3);
   __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
 
-  for (uint64_t i = 0; i < 1000000; i++) { }
+  for (uint64_t i = 0; i < 100; i++) { __asm__ __volatile__ ("nop"); }
 
   bp_finish(1);
 }

--- a/src/interrupt_priority.h
+++ b/src/interrupt_priority.h
@@ -1,0 +1,41 @@
+
+#ifndef INTERRUPT_PRIORITY_H
+#define INTERRUPT_PRIORITY_H
+
+// CLINT/PLIC base and offsets (see bp_common_clint_pkgdef.svh)
+#define CLINT_BASE_ADDR        0x00300000ull
+#define CLINT_MIPI_OFFSET      0x0000ull
+#define CLINT_MTIMECMP_OFFSET  0x4000ull
+#define CLINT_MTIME_OFFSET     0xBFF8ull
+#define CLINT_PLIC_OFFSET      0xC000ull
+#define CLINT_PLIC_STRIDE      0x0008ull
+
+__attribute__((always_inline)) static inline void mmio_write64(uint64_t addr, uint64_t val) {
+  *(volatile uint64_t *)addr = val;
+}
+
+__attribute__((always_inline)) static inline void mmio_write32(uint64_t addr, uint32_t val) {
+  *(volatile uint32_t *)addr = val;
+}
+
+__attribute__((always_inline)) static inline uint64_t mmio_read64(uint64_t addr) {
+  return *(volatile uint64_t *)addr;
+}
+
+static inline void clint_set_msip(uint32_t val) {
+  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+}
+
+static inline void clint_set_mtimecmp(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
+}
+
+static inline uint64_t clint_read_mtime(void) {
+  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
+}
+
+static inline void clint_set_meip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
+}
+
+#endif

--- a/src/interrupt_priority_race.c
+++ b/src/interrupt_priority_race.c
@@ -13,12 +13,16 @@ static inline void mmio_write64(uint64_t addr, uint64_t val) {
   *(volatile uint64_t *)addr = val;
 }
 
+static inline void mmio_write32(uint64_t addr, uint32_t val) {
+  *(volatile uint32_t *)addr = val;
+}
+
 static inline uint64_t mmio_read64(uint64_t addr) {
   return *(volatile uint64_t *)addr;
 }
 
-static inline void clint_set_msip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+static inline void clint_set_msip(uint32_t val) {
+  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
 }
 
 static inline void clint_set_mtimecmp(uint64_t val) {

--- a/src/interrupt_priority_race.c
+++ b/src/interrupt_priority_race.c
@@ -1,41 +1,7 @@
 // This test checks M-mode interrupt priority across pending/enable race orderings.
 #include <stdint.h>
 #include "bp_utils.h"
-
-#define CLINT_BASE_ADDR        0x00300000ull
-#define CLINT_MIPI_OFFSET      0x0000ull
-#define CLINT_MTIMECMP_OFFSET  0x4000ull
-#define CLINT_MTIME_OFFSET     0xBFF8ull
-#define CLINT_PLIC_OFFSET      0xB000ull
-#define CLINT_PLIC_STRIDE      0x0008ull
-
-static inline void mmio_write64(uint64_t addr, uint64_t val) {
-  *(volatile uint64_t *)addr = val;
-}
-
-static inline void mmio_write32(uint64_t addr, uint32_t val) {
-  *(volatile uint32_t *)addr = val;
-}
-
-static inline uint64_t mmio_read64(uint64_t addr) {
-  return *(volatile uint64_t *)addr;
-}
-
-static inline void clint_set_msip(uint32_t val) {
-  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
-}
-
-static inline void clint_set_mtimecmp(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
-}
-
-static inline uint64_t clint_read_mtime(void) {
-  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
-}
-
-static inline void clint_set_meip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
-}
+#include "interrupt_priority.h"
 
 static const uint64_t expected_ecode[6] = {11, 3, 7, 11, 3, 7};
 volatile uint64_t step = 0;

--- a/src/interrupt_priority_race.c
+++ b/src/interrupt_priority_race.c
@@ -1,0 +1,107 @@
+// This test checks M-mode interrupt priority across pending/enable race orderings.
+#include <stdint.h>
+#include "bp_utils.h"
+
+#define CLINT_BASE_ADDR        0x00300000ull
+#define CLINT_MIPI_OFFSET      0x0000ull
+#define CLINT_MTIMECMP_OFFSET  0x4000ull
+#define CLINT_MTIME_OFFSET     0xBFF8ull
+#define CLINT_PLIC_OFFSET      0xB000ull
+#define CLINT_PLIC_STRIDE      0x0008ull
+
+static inline void mmio_write64(uint64_t addr, uint64_t val) {
+  *(volatile uint64_t *)addr = val;
+}
+
+static inline uint64_t mmio_read64(uint64_t addr) {
+  return *(volatile uint64_t *)addr;
+}
+
+static inline void clint_set_msip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+}
+
+static inline void clint_set_mtimecmp(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
+}
+
+static inline uint64_t clint_read_mtime(void) {
+  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
+}
+
+static inline void clint_set_meip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
+}
+
+static const uint64_t expected_ecode[6] = {11, 3, 7, 11, 3, 7};
+volatile uint64_t step = 0;
+
+void trap_handler(void) __attribute__((interrupt));
+void trap_handler(void) {
+  uint64_t mcause;
+  __asm__ __volatile__ ("csrr %0, mcause" : "=r" (mcause));
+
+  if ((mcause >> 63) == 0)
+    bp_finish(1);
+
+  if (step >= 6)
+    bp_finish(1);
+
+  uint64_t ecode = mcause & 0xfff;
+  if (ecode != expected_ecode[step])
+    bp_finish(1);
+
+  if (ecode == 11)
+    clint_set_meip(0);
+  else if (ecode == 3)
+    clint_set_msip(0);
+  else if (ecode == 7)
+    clint_set_mtimecmp(~0ull);
+  else
+    bp_finish(1);
+
+  step++;
+
+  // After finishing the pending-before-enable phase, exercise enable-before-pending.
+  if (step == 3) {
+    clint_set_msip(1);
+    clint_set_meip(1);
+    clint_set_mtimecmp(clint_read_mtime());
+    __asm__ __volatile__ ("fence iorw, iorw" : : : "memory");
+    return;
+  }
+
+  if (step == 6)
+    bp_finish(0);
+}
+
+int main(uint64_t argc, char * argv[]) {
+  __asm__ __volatile__ ("csrw mtvec, %0" : : "r" (&trap_handler));
+
+  uint64_t mstatus;
+  __asm__ __volatile__ ("csrr %0, mstatus" : "=r" (mstatus));
+  mstatus &= ~(1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  uint64_t mie = (1ULL << 3) | (1ULL << 7) | (1ULL << 11);
+  __asm__ __volatile__ ("csrw mie, %0" : : "r" (mie));
+
+  // Clear stale state first.
+  clint_set_msip(0);
+  clint_set_meip(0);
+  clint_set_mtimecmp(~0ull);
+
+  // Phase A: pending-before-enable.
+  clint_set_msip(1);
+  clint_set_meip(1);
+  clint_set_mtimecmp(clint_read_mtime());
+
+  __asm__ __volatile__ ("fence iorw, iorw" : : : "memory");
+
+  mstatus |= (1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  for (uint64_t i = 0; i < 2000000; i++) { }
+
+  bp_finish(1);
+}

--- a/src/interrupt_priority_simultaneous.c
+++ b/src/interrupt_priority_simultaneous.c
@@ -13,12 +13,16 @@ static inline void mmio_write64(uint64_t addr, uint64_t val) {
   *(volatile uint64_t *)addr = val;
 }
 
+static inline void mmio_write32(uint64_t addr, uint32_t val) {
+  *(volatile uint32_t *)addr = val;
+}
+
 static inline uint64_t mmio_read64(uint64_t addr) {
   return *(volatile uint64_t *)addr;
 }
 
-static inline void clint_set_msip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+static inline void clint_set_msip(uint32_t val) {
+  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
 }
 
 static inline void clint_set_mtimecmp(uint64_t val) {

--- a/src/interrupt_priority_simultaneous.c
+++ b/src/interrupt_priority_simultaneous.c
@@ -1,41 +1,7 @@
 // This test checks M-mode interrupt priority when all sources are pending together.
 #include <stdint.h>
 #include "bp_utils.h"
-
-#define CLINT_BASE_ADDR        0x00300000ull
-#define CLINT_MIPI_OFFSET      0x0000ull
-#define CLINT_MTIMECMP_OFFSET  0x4000ull
-#define CLINT_MTIME_OFFSET     0xBFF8ull
-#define CLINT_PLIC_OFFSET      0xB000ull
-#define CLINT_PLIC_STRIDE      0x0008ull
-
-static inline void mmio_write64(uint64_t addr, uint64_t val) {
-  *(volatile uint64_t *)addr = val;
-}
-
-static inline void mmio_write32(uint64_t addr, uint32_t val) {
-  *(volatile uint32_t *)addr = val;
-}
-
-static inline uint64_t mmio_read64(uint64_t addr) {
-  return *(volatile uint64_t *)addr;
-}
-
-static inline void clint_set_msip(uint32_t val) {
-  mmio_write32(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
-}
-
-static inline void clint_set_mtimecmp(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
-}
-
-static inline uint64_t clint_read_mtime(void) {
-  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
-}
-
-static inline void clint_set_meip(uint64_t val) {
-  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
-}
+#include "interrupt_priority.h"
 
 volatile uint64_t step = 0;
 

--- a/src/interrupt_priority_simultaneous.c
+++ b/src/interrupt_priority_simultaneous.c
@@ -1,0 +1,104 @@
+// This test checks M-mode interrupt priority when all sources are pending together.
+#include <stdint.h>
+#include "bp_utils.h"
+
+#define CLINT_BASE_ADDR        0x00300000ull
+#define CLINT_MIPI_OFFSET      0x0000ull
+#define CLINT_MTIMECMP_OFFSET  0x4000ull
+#define CLINT_MTIME_OFFSET     0xBFF8ull
+#define CLINT_PLIC_OFFSET      0xB000ull
+#define CLINT_PLIC_STRIDE      0x0008ull
+
+static inline void mmio_write64(uint64_t addr, uint64_t val) {
+  *(volatile uint64_t *)addr = val;
+}
+
+static inline uint64_t mmio_read64(uint64_t addr) {
+  return *(volatile uint64_t *)addr;
+}
+
+static inline void clint_set_msip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MIPI_OFFSET, val);
+}
+
+static inline void clint_set_mtimecmp(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_MTIMECMP_OFFSET, val);
+}
+
+static inline uint64_t clint_read_mtime(void) {
+  return mmio_read64(CLINT_BASE_ADDR + CLINT_MTIME_OFFSET);
+}
+
+static inline void clint_set_meip(uint64_t val) {
+  mmio_write64(CLINT_BASE_ADDR + CLINT_PLIC_OFFSET + (0 * CLINT_PLIC_STRIDE), val);
+}
+
+volatile uint64_t step = 0;
+
+void trap_handler(void) __attribute__((interrupt));
+void trap_handler(void) {
+  uint64_t mcause;
+  __asm__ __volatile__ ("csrr %0, mcause" : "=r" (mcause));
+
+  if ((mcause >> 63) == 0)
+    bp_finish(1);
+
+  uint64_t ecode = mcause & 0xfff;
+
+  if (step == 0) {
+    if (ecode != 11)
+      bp_finish(1);
+    clint_set_meip(0);
+    step = 1;
+    return;
+  }
+
+  if (step == 1) {
+    if (ecode != 3)
+      bp_finish(1);
+    clint_set_msip(0);
+    step = 2;
+    return;
+  }
+
+  if (step == 2) {
+    if (ecode != 7)
+      bp_finish(1);
+    clint_set_mtimecmp(~0ull);
+    bp_finish(0);
+  }
+
+  bp_finish(1);
+}
+
+int main(uint64_t argc, char * argv[]) {
+  __asm__ __volatile__ ("csrw mtvec, %0" : : "r" (&trap_handler));
+
+  uint64_t mstatus;
+  __asm__ __volatile__ ("csrr %0, mstatus" : "=r" (mstatus));
+  mstatus &= ~(1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  // Enable all machine interrupt classes up front.
+  uint64_t mie = (1ULL << 3) | (1ULL << 7) | (1ULL << 11);
+  __asm__ __volatile__ ("csrw mie, %0" : : "r" (mie));
+
+  // Clear stale state.
+  clint_set_msip(0);
+  clint_set_meip(0);
+  clint_set_mtimecmp(~0ull);
+
+  // Arm all pending sources before turning on MIE.
+  clint_set_msip(1);
+  clint_set_meip(1);
+  clint_set_mtimecmp(clint_read_mtime());
+
+  __asm__ __volatile__ ("fence iorw, iorw" : : : "memory");
+
+  mstatus |= (1ULL << 3);
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  for (uint64_t i = 0; i < 1000000; i++) { }
+
+  bp_finish(1);
+}


### PR DESCRIPTION
Related: black-parrot/black-parrot#1287

## Summary:
  - Add directed baseline interrupt priority test updates
  - Add simultaneous-pending test (interrupt_priority_simultaneous)
  - Add pending/enable race test (interrupt_priority_race)
  - Add tests to Makefile.frag list

## Validation:
  - Local Verilator PASS: interrupt_priority
  - Local Verilator PASS: interrupt_priority_simultaneous
  - Local Verilator PASS: interrupt_priority_race"
  
## Notes
1.The new interrupt-priority tests (interrupt_priority, interrupt_priority_simultaneous, interrupt_priority_race) are validated in RTL/Verilator flow.
2.These tests currently use BP-specific CLINT/PLIC MMIO behavior for MEIP injection.
3.Raw dromajo/spike may not model this path equivalently yet, so direct ISA-sim execution can fail with out-of-range CLINT/MSIP accesses.
4.Simulator-model compatibility is expected as a follow-up.
