### PR TITLE
Add high_dram_alias regression for higher DRAM space

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -26,6 +26,7 @@ BP_TESTS_C = \
   epc                   \
   fflags_haz            \
   dram_stress           \
+  high_dram_alias       \
   misaligned_ldst       \
   nanboxing             \
   misaligned_instructions_basic_jumps \

--- a/src/high_dram_alias.c
+++ b/src/high_dram_alias.c
@@ -1,0 +1,40 @@
+
+#include <stdint.h>
+#include <bp_utils.h>
+
+void main(uint64_t argc, char *argv[]) {
+  volatile uint64_t *low_addr  = (volatile uint64_t *)0x083000000ULL;
+  volatile uint64_t *high_addr = (volatile uint64_t *)0x183000000ULL;
+
+  uint64_t pattern_low   = 0x1122334455667788ULL;
+  uint64_t pattern_high  = 0xAABBCCDDEEFF0011ULL;
+  uint64_t pattern_low2  = 0x55AA55AA55AA55AAULL;
+  uint64_t pattern_high2 = 0xCAFEBABECAFED00DULL;
+
+  *low_addr = pattern_low;
+  if (*low_addr != pattern_low)
+    bp_finish(1);
+
+  *high_addr = pattern_high;
+  if (*high_addr != pattern_high)
+    bp_finish(1);
+
+  if (*low_addr != pattern_low)
+    bp_finish(1);
+
+  *low_addr = pattern_low2;
+  if (*low_addr != pattern_low2)
+    bp_finish(1);
+
+  if (*high_addr != pattern_high)
+    bp_finish(1);
+
+  *high_addr = pattern_high2;
+  if (*high_addr != pattern_high2)
+    bp_finish(1);
+
+  if (*low_addr != pattern_low2)
+    bp_finish(1);
+
+  bp_finish(0);
+}

--- a/src/high_dram_alias.c
+++ b/src/high_dram_alias.c
@@ -1,40 +1,59 @@
-
 #include <stdint.h>
 #include <bp_utils.h>
 
-void main(uint64_t argc, char *argv[]) {
+static inline void store64(volatile uint64_t *addr, uint64_t val) {
+  __asm__ __volatile__("sd %1, 0(%0)" : : "r"(addr), "r"(val) : "memory");
+}
+
+static inline uint64_t load64(volatile uint64_t *addr) {
+  uint64_t val;
+  __asm__ __volatile__("ld %0, 0(%1)" : "=r"(val) : "r"(addr) : "memory");
+  return val;
+}
+
+int main() {
+  volatile uint64_t *cfg_reg_dcache_mode = (volatile uint64_t *)0x200408ULL;
   volatile uint64_t *low_addr  = (volatile uint64_t *)0x083000000ULL;
   volatile uint64_t *high_addr = (volatile uint64_t *)0x183000000ULL;
 
-  uint64_t pattern_low   = 0x1122334455667788ULL;
-  uint64_t pattern_high  = 0xAABBCCDDEEFF0011ULL;
-  uint64_t pattern_low2  = 0x55AA55AA55AA55AAULL;
-  uint64_t pattern_high2 = 0xCAFEBABECAFED00DULL;
+  const uint64_t pattern_low  = 0x1122334455667788ULL;
+  const uint64_t pattern_high = 0xAABBCCDDEEFF0011ULL;
 
-  *low_addr = pattern_low;
-  if (*low_addr != pattern_low)
+  uint64_t value;
+
+  // Force uncached mode so cache state cannot hide aliasing
+  store64(cfg_reg_dcache_mode, 0);
+
+  store64(low_addr, pattern_low);
+  value = load64(low_addr);
+  bp_print_string("low after low write: ");
+  bp_hprint_uint64(value);
+  bp_cprint('\n');
+  if (value != pattern_low)
     bp_finish(1);
 
-  *high_addr = pattern_high;
-  if (*high_addr != pattern_high)
+  store64(high_addr, pattern_high);
+  value = load64(high_addr);
+  bp_print_string("high after high write: ");
+  bp_hprint_uint64(value);
+  bp_cprint('\n');
+  if (value != pattern_high)
     bp_finish(1);
 
-  if (*low_addr != pattern_low)
+  value = load64(low_addr);
+  bp_print_string("low after high write: ");
+  bp_hprint_uint64(value);
+  bp_cprint('\n');
+  if (value != pattern_low)
     bp_finish(1);
 
-  *low_addr = pattern_low2;
-  if (*low_addr != pattern_low2)
-    bp_finish(1);
-
-  if (*high_addr != pattern_high)
-    bp_finish(1);
-
-  *high_addr = pattern_high2;
-  if (*high_addr != pattern_high2)
-    bp_finish(1);
-
-  if (*low_addr != pattern_low2)
+  value = load64(high_addr);
+  bp_print_string("high final: ");
+  bp_hprint_uint64(value);
+  bp_cprint('\n');
+  if (value != pattern_high)
     bp_finish(1);
 
   bp_finish(0);
+  return 0;
 }


### PR DESCRIPTION
## Summary

Adds a directed `bp-tests` regression, `high_dram_alias`, to check whether two DRAM addresses separated by the upper address bit remain independent.

## Local validation

* `e_bp_default_cfg` → fails
* `e_bp_custom_cfg` with a minimal local address-width override → passes

This gives a clean fail-before / pass-after result for the higher-DRAM-space issue.

## Files

* `src/high_dram_alias.c`
* `Makefile.frag`