### PR TITLE
Fix cycle mismatch in MMU eaddr bounds check and update OOB test

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,4 +1,5 @@
 BP_TESTS_C = \
+  out_of_bounds_test    \
   m_external_interrupt  \
   s_external_interrupt  \
   hello_world           \

--- a/src/out_of_bounds_test.S
+++ b/src/out_of_bounds_test.S
@@ -1,39 +1,50 @@
-#include "riscv_test.h"
-#include "test_macros.h"
+.section .text
+.global main
 
-RVTEST_RV64U
-RVTEST_CODE_BEGIN
+main:
+    # 1. Set up the trap handler vector
+    la t0, trap_handler
+    csrw mtvec, t0
+    
+    # 2. Set up the test addresses
+    li t1, 0x4000000000000000  # Address that triggers OOB (exceeds physical width)
+    la t3, valid_data          # Valid memory address in the .data section
 
-  # Save original trap vector
-  csrr t5, mtvec
-  
-  # Register our trap handler
-  la t0, trap_vector
-  csrw mtvec, t0
+    # 3. BACK-TO-BACK memory operations to test cycle alignment!
+    lw x0, 0(t3)               # Valid load (Should NOT fault)
+    lw t2, 0(t1)               # OOB load (SHOULD fault and jump to trap_handler)
+    
+    # 4. If we reach this line, the OOB load failed to trigger a trap!
+    j fail                     
 
-  # Trigger the fault: Load from an address outside paddr_width_p
-  li t1, 0x4000000000000000 
-  lw t2, 0(t1)
-
-  # If we reach here, hardware DID NOT trap (Failure)
-  j fail
-
-trap_vector:
-  # Check cause (mcause == 5 for Load Access Fault)
-  csrr t3, mcause
-  li t4, 5
-  bne t3, t4, fail
+trap_handler:
+    # 5. Verify the trap was actually caused by our OOB load
+    csrr t3, mcause
+    li t4, 5                   # Expecting Exception 5: Load Access Fault
+    bne t3, t4, fail
+    # If it is exactly 5, the test worked perfectly! Fall through to pass.
 
 pass:
-  csrw mtvec, t5
-  RVTEST_PASS
+    # Signal success (1) to the Verilator/BlackParrot testbench
+    li t0, 0x02110000          # Perch finish register
+    li t1, 0x1
+    sw t1, 0(t0)
+
+test_done:
+    wfi                        # Halt processor
+    j test_done
 
 fail:
-  RVTEST_FAIL
+    # Signal failure (2) to the Verilator/BlackParrot testbench
+    li t0, 0x02110000          # Perch finish register
+    li t1, 0x2
+    sw t1, 0(t0)
+    
+fail_loop:
+    wfi                        # Halt processor
+    j fail_loop
 
-RVTEST_CODE_END
-
-.data
-RVTEST_DATA_BEGIN
-  TEST_DATA
-RVTEST_DATA_END
+.section .data
+.align 3
+valid_data:
+    .dword 0xDEADBEEF          # Safe dummy data to read for the valid load

--- a/src/out_of_bounds_test.S
+++ b/src/out_of_bounds_test.S
@@ -17,6 +17,7 @@ main:
     # 4. If we reach this line, the OOB load failed to trigger a trap!
     j fail                     
 
+.align 2
 trap_handler:
     # 5. Verify the trap was actually caused by our OOB load
     csrr t3, mcause
@@ -25,9 +26,9 @@ trap_handler:
     # If it is exactly 5, the test worked perfectly! Fall through to pass.
 
 pass:
-    # Signal success (1) to the Verilator/BlackParrot testbench
-    li t0, 0x02110000          # Perch finish register
-    li t1, 0x1
+    # Signal success (0) to the Verilator/BlackParrot testbench
+    li t0, 0x00102000          # Perch finish register
+    li t1, 0x0
     sw t1, 0(t0)
 
 test_done:
@@ -36,7 +37,7 @@ test_done:
 
 fail:
     # Signal failure (2) to the Verilator/BlackParrot testbench
-    li t0, 0x02110000          # Perch finish register
+    li t0, 0x00102000          # Perch finish register
     li t1, 0x2
     sw t1, 0(t0)
     

--- a/src/out_of_bounds_test.S
+++ b/src/out_of_bounds_test.S
@@ -1,0 +1,39 @@
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # Save original trap vector
+  csrr t5, mtvec
+  
+  # Register our trap handler
+  la t0, trap_vector
+  csrw mtvec, t0
+
+  # Trigger the fault: Load from an address outside paddr_width_p
+  li t1, 0x4000000000000000 
+  lw t2, 0(t1)
+
+  # If we reach here, hardware DID NOT trap (Failure)
+  j fail
+
+trap_vector:
+  # Check cause (mcause == 5 for Load Access Fault)
+  csrr t3, mcause
+  li t4, 5
+  bne t3, t4, fail
+
+pass:
+  csrw mtvec, t5
+  RVTEST_PASS
+
+fail:
+  RVTEST_FAIL
+
+RVTEST_CODE_END
+
+.data
+RVTEST_DATA_BEGIN
+  TEST_DATA
+RVTEST_DATA_END


### PR DESCRIPTION
**Problem:**
The out-of-bounds check in `bp_mmu.sv` was mixing a Cycle 0 input (`r_eaddr_i`) with Cycle 1 registers (`r_load_r`). This caused the bounds check to misalign with the current instruction. The original test only passed because the pipeline was stalling and holding the input constant.

**Solution:**
* Updated `bp_common/src/v/bp_mmu.sv` to check the registered tag instead: `|r_etag_r[etag_width_p-1 : ptag_width_p];`
* Rewrote `out_of_bounds_test.S` to be cycle-accurate and robust against pipeline stalls. It now executes a back-to-back valid load followed immediately by an out-of-bounds load to ensure the pipeline doesn't falsely trap.

**Verification:**
Verified locally in Verilator. The trace confirms the out-of-bounds load successfully triggers Exception 5:
`0 3 000000008000032c (0x00032383) exception (0000000000000005) -> 0x0080000330`